### PR TITLE
Added status-code 10 to status_table dictionary

### DIFF
--- a/pushservices/apns.py
+++ b/pushservices/apns.py
@@ -176,6 +176,7 @@ class APNClient(PushService):
                 6: "Invalid topic size",
                 7: "Invalid payload size",
                 8: "Invalid token",
+               10: "Shutdown",
               255: "None"}
         # The error response packet
         """


### PR DESCRIPTION
The status code for Shutdown (Status = 10) was only added to the
comments and not to the actual status_table dictionary. The APNS module
crashes the moment it encounters status 10. This commit is a fix for
that.
